### PR TITLE
test: confidence testing post-deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
-          disable-sudo-and-containers: true
+          disable-sudo-and-containers: false
           egress-policy: block
           allowed-endpoints: >
             github.com:443

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,8 @@
       "dependsOn": ["^check-types"]
     },
     "browsers": {
-      "dependsOn": ["^browsers"]
+      "dependsOn": ["^browsers"],
+      "cache": false
     },
     "ci": {
       "dependsOn": ["build", "e2e"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to allow sudo privileges and container capabilities in the confidence job.
  * Disabled caching for the "browsers" task to ensure it always runs fresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->